### PR TITLE
Project setup

### DIFF
--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/ContentUnderstanding.MCP.Server.Stdio.csproj
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/ContentUnderstanding.MCP.Server.Stdio.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/ContentUnderstanding.MCP.Server.Stdio.csproj
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/ContentUnderstanding.MCP.Server.Stdio.csproj
@@ -7,4 +7,17 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.6.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.4.3-preview.1.25230.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.48.0" />
+    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentUnderstanding.MCP.Tools\ContentUnderstanding.MCP.Tools.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Extensions/McpServerBuilderExtensions.cs
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Extensions/McpServerBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
+
+namespace ContentUnderstanding.MCP.Server.Stdio.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IMcpServerBuilder"/>.
+/// </summary>
+public static class McpServerBuilderExtensions
+{
+  /// <summary>
+  /// Adds all functions of the kernel plugins as tools to the server.
+  /// </summary>
+  /// <param name="builder">The builder instance.</param>
+  /// <param name="plugins">The kernel plugins to add as tools to the server.</param>
+  /// <returns>The builder instance.</returns>
+  public static IMcpServerBuilder WithTools(this IMcpServerBuilder builder, KernelPluginCollection plugins)
+  {
+    foreach (var plugin in plugins)
+    {
+      foreach (var function in plugin)
+      {
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        builder.Services.AddSingleton(services => McpServerTool.Create(function.AsAIFunction()));
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+      }
+    }
+
+    return builder;
+  }
+}

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddSingleton(sp => KernelPluginFactory.CreateFromType<DummyTool
 
 var apiKey = builder.Configuration["Ynab:ApiKey"];
 
+// Use this to talk to the Content Understanding REST API
 builder.Services.AddHttpClient();
 
 var kernel = builder.Services.BuildServiceProvider().GetRequiredService<Kernel>();

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.cs
@@ -1,2 +1,45 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using System.Net.Http.Headers;
+using ContentUnderstanding.MCP.Server.Stdio.Extensions;
+using ContentUnderstanding.MCP.Tools;
+
+var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+
+builder.Configuration
+  .AddJsonFile("appsettings.json", optional: true)
+  .AddUserSecrets<Program>()
+  .AddEnvironmentVariables();
+
+builder.Services.AddLogging(configure =>
+  configure
+    .AddConfiguration(builder.Configuration.GetSection("Logging"))
+    .AddFile(o => o.RootPath = AppContext.BaseDirectory)
+    .SetMinimumLevel(LogLevel.Debug)
+);
+
+builder.Services.AddKernel();
+
+builder.Services.AddSingleton(sp => KernelPluginFactory.CreateFromType<DummyTool>(serviceProvider: sp));
+
+var apiKey = builder.Configuration["Ynab:ApiKey"];
+
+builder.Services.AddHttpClient();
+
+var kernel = builder.Services.BuildServiceProvider().GetRequiredService<Kernel>();
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithTools(kernel.Plugins);
+
+var app = builder.Build();
+
+var logger = app.Services.GetRequiredService<ILogger<Program>>();
+
+logger.LogInformation("Starting Content Understanding MCP Server");
+await app.RunAsync();
+logger.LogInformation("Shutting down Content Understanding MCP Server");

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.sln
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentUnderstanding.MCP.Server.Stdio", "ContentUnderstanding.MCP.Server.Stdio\ContentUnderstanding.MCP.Server.Stdio.csproj", "{70981E07-3189-47D7-AFBC-15BB40741C63}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentUnderstanding.MCP.Tools", "ContentUnderstanding.MCP.Tools\ContentUnderstanding.MCP.Tools.csproj", "{9F75D543-65AD-49A4-B51F-569F17DEFE32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{70981E07-3189-47D7-AFBC-15BB40741C63}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70981E07-3189-47D7-AFBC-15BB40741C63}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70981E07-3189-47D7-AFBC-15BB40741C63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F75D543-65AD-49A4-B51F-569F17DEFE32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F75D543-65AD-49A4-B51F-569F17DEFE32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F75D543-65AD-49A4-B51F-569F17DEFE32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F75D543-65AD-49A4-B51F-569F17DEFE32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.sln
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentUnderstanding.MCP.Server.Stdio", "ContentUnderstanding.MCP.Server.Stdio\ContentUnderstanding.MCP.Server.Stdio.csproj", "{70981E07-3189-47D7-AFBC-15BB40741C63}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{70981E07-3189-47D7-AFBC-15BB40741C63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70981E07-3189-47D7-AFBC-15BB40741C63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70981E07-3189-47D7-AFBC-15BB40741C63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70981E07-3189-47D7-AFBC-15BB40741C63}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BCA92007-93E2-44C6-B7F1-AEB768F50A7E}
+	EndGlobalSection
+EndGlobal

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/ContentUnderstanding.MCP.Tools.csproj
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/ContentUnderstanding.MCP.Tools.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/DummyTool.cs
+++ b/ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/DummyTool.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ContentUnderstanding.MCP.Tools;
+
+public class DummyTool
+{
+}


### PR DESCRIPTION
This pull request introduces a new project for the Content Understanding MCP Server with a focus on setting up the `Stdio` server and its supporting tools. Key changes include the creation of new projects, implementation of server setup logic, and integration of tools and plugins.

### Project Setup and Configuration:
* Added a new `ContentUnderstanding.MCP.Server.Stdio` project targeting .NET 9.0 with dependencies on various Microsoft and third-party libraries, including `Microsoft.SemanticKernel` and `ModelContextProtocol`. (`ContentUnderstanding.MCP.Server.Stdio.csproj`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/ContentUnderstanding.MCP.Server.Stdio.csprojR1-R23](diffhunk://#diff-b126cffddb1cee7006695826fdfa37e4c063e0660c267adf07a466b65c08bb60R1-R23))
* Created a solution file (`ContentUnderstanding.MCP.Server.sln`) to include the `Stdio` server and `Tools` projects. (`ContentUnderstanding.MCP.Server.sln`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.slnR1-R31](diffhunk://#diff-70201591fa4d91403925b7c429bf3d212528080ec05db21c9f4a4edef2227b5eR1-R31))

### Server Implementation:
* Implemented the `Program.cs` file for the `Stdio` server, configuring logging, dependency injection, and server tools using kernel plugins. (`Program.cs`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Program.csR1-R45](diffhunk://#diff-a587ab221924adf925d025b8800150b9d0317ae86bf4309a99a99dc52d049a91R1-R45))
* Added an extension method `WithTools` in `McpServerBuilderExtensions` to register kernel plugin functions as server tools. (`McpServerBuilderExtensions.cs`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Server.Stdio/Extensions/McpServerBuilderExtensions.csR1-R34](diffhunk://#diff-a9aabeda56f140e17aeb1126b743e9274aa54f3eeebca64f3897cb6522cf7044R1-R34))

### Tools Project:
* Created a new `ContentUnderstanding.MCP.Tools` project targeting .NET 9.0, intended for reusable tools. (`ContentUnderstanding.MCP.Tools.csproj`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/ContentUnderstanding.MCP.Tools.csprojR1-R9](diffhunk://#diff-39cdb3b4d36d8b7b11430f2806f91dd54e9ea4745efd718a0ed5131f97bb3823R1-R9))
* Added a placeholder `DummyTool` class in the `Tools` project for future development. (`DummyTool.cs`, [ContentUnderstanding.MCP.Server/ContentUnderstanding.MCP.Tools/DummyTool.csR1-R11](diffhunk://#diff-a66ffe6b2b3486776e851b53a358c950e7566717a018146bef4b9b4520409029R1-R11))